### PR TITLE
change redirect_canonical filter parameters.

### DIFF
--- a/options/mu-plugins/cf-hostfix.php
+++ b/options/mu-plugins/cf-hostfix.php
@@ -7,7 +7,7 @@ Version: 0.1
 Author:hideokamoto
 Author URI:
 */
-add_action('redirect_canonical', 'change_requested_url');
+add_filter('redirect_canonical', 'change_requested_url', 10, 2);
 function change_requested_url($redirect_url, $requested_url) {
 	$redirect_url = is_ssl() ? 'https://' : 'http://';
 	$redirect_url .= $_SERVER['HTTP_HOST'];


### PR DESCRIPTION
output these warning logs in my AMIMOTO instance. (/var/log/hhvm/error.log)
Warning: change_requested_url() expects exactly 2 parameters, 1 given in /var/www/vhosts/i-********/wp-content/plugins/cf-hostfix.php on line 12